### PR TITLE
Fix to load dependent assembly from specified path

### DIFF
--- a/AddInManager/Model/AssemLoader.cs
+++ b/AddInManager/Model/AssemLoader.cs
@@ -157,6 +157,14 @@ public class AssemLoader
                     {
                         ass = ass.Substring(0, ass.Length - ".resources".Length);
                     }
+                    // Skip searching for the assembly if assembly with specified name is already loaded
+                    foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                    {
+                        if (String.Compare(assembly.GetName().Name, ass, StringComparison.OrdinalIgnoreCase) == 0)
+                        {
+                            return null;
+                        }
+                    }
                     filePath = SearchAssemblyFileInTempFolder(ass);
                     if (File.Exists(filePath))
                     {
@@ -188,7 +196,9 @@ public class AssemLoader
             var array = new string[] { ".dll", ".exe" };
             var filePath = string.Empty;
             if(string.IsNullOrEmpty(assemName)) return String.Empty;
-            var str = assemName.Substring(0, assemName.IndexOf(','));
+            // Avoid ArgumentOutOfRangeException from .Substring() by checking length parameter
+            var strLength = assemName.IndexOf(',');
+            var str = strLength == -1 ? assemName : assemName.Substring(0, strLength);
             foreach (var str2 in array)
             {
                 filePath = tempFolder + "\\" + str + str2;
@@ -214,7 +224,9 @@ public class AssemLoader
             ".exe"
         };
         string filePath;
-        var ass = assemName.Substring(0, assemName.IndexOf(','));
+        // Avoid ArgumentOutOfRangeException from .Substring() by checking length parameter
+        var assLength = assemName.IndexOf(',');
+        var ass = assLength == -1 ? assemName : assemName.Substring(0, assLength);
         foreach (var str in extensions)
         {
             filePath = dotnetDir + "\\" + ass + str;

--- a/AddInManager/View/AssemblyLoader.xaml.cs
+++ b/AddInManager/View/AssemblyLoader.xaml.cs
@@ -41,9 +41,12 @@ public partial class AssemblyLoader : Window
         openFileDialog.FileName = str + ".*";
         if (openFileDialog.ShowDialog() == true)
         {
-            ShowWarning();
+            TbxAssemPath.Text = openFileDialog.FileName;
         }
-        TbxAssemPath.Text = openFileDialog.FileName;
+        else
+        {
+            TbxAssemPath.Text = string.Empty;
+        }
     }
 
     private void OKButtonClick(object sender, RoutedEventArgs e)
@@ -52,10 +55,8 @@ public partial class AssemblyLoader : Window
         {
             resultPath = TbxAssemPath.Text;
             isFound = true;
-        }
-        else
-        {
-            ShowWarning();
+            // Set ShowDialog() to return true after closing with Ok button
+            this.DialogResult = true;
         }
         Close();
     }


### PR DESCRIPTION
### Purpose

Small fix to enable loading dependent assemblies from specified path

### Description

Fixed ArgumentOutOfRangeException from .Substring() by checking length parameter
	- in case when we are running .IndexOf(',') on already stripped from commas "NameOfYourAddInDll"
Added check to skip searching for the assembly if assembly with specified name is already loaded
	- in case when AssemblyResolve tries to find "NameOfYourAddInDll.resources" and ".resources" is stripped from the name
Fixed return value from ShowDialog() to return true after closing with Ok button 
Removed confusing (duplicated) ShowWarning() when the dependent assembly can't be loaded

### Declarations

Check these if you believe they are true

- [x] This PR fix bug
- [ ] This PR for new feature
- [ ] The codebase is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

 @chuongmep 

### FYIs

